### PR TITLE
Make CryptoInfo public

### DIFF
--- a/ktls/src/ffi.rs
+++ b/ktls/src/ffi.rs
@@ -72,7 +72,8 @@ pub enum CryptoInfo {
 }
 
 impl CryptoInfo {
-    fn as_ptr(&self) -> *const libc::c_void {
+    /// Return the system struct as a pointer.
+    pub fn as_ptr(&self) -> *const libc::c_void {
         match self {
             CryptoInfo::AesGcm128(info) => info as *const _ as *const libc::c_void,
             CryptoInfo::AesGcm256(info) => info as *const _ as *const libc::c_void,
@@ -83,7 +84,8 @@ impl CryptoInfo {
         }
     }
 
-    fn size(&self) -> usize {
+    /// Return the system struct size.
+    pub fn size(&self) -> usize {
         match self {
             CryptoInfo::AesGcm128(_) => std::mem::size_of::<ktls::tls12_crypto_info_aes_gcm_128>(),
             CryptoInfo::AesGcm256(_) => std::mem::size_of::<ktls::tls12_crypto_info_aes_gcm_256>(),

--- a/ktls/src/lib.rs
+++ b/ktls/src/lib.rs
@@ -25,7 +25,7 @@ use tokio::{
 };
 
 mod ffi;
-use crate::ffi::CryptoInfo;
+pub use crate::ffi::CryptoInfo;
 
 mod async_read_ready;
 pub use async_read_ready::AsyncReadReady;


### PR DESCRIPTION
In order to do kTLS with `io-uring`, I needed two things:

1. `io-uring` to support `setsockopt`. This is https://github.com/tokio-rs/io-uring/pull/320
2. `ktls` to help turn `rustls` connection state into a struct suitable for the KTLS `setsockopt` calls. This is the PR here.

I have some very ugly use in [this repo](https://github.com/ThomasHabets/tarweb/blob/3045d190bb945f645aff337bea949eef44c6a061/rust/src/main.rs#L317-L377), but the short version is: This definitely works, and I believe that `CryptoInfo` is exactly of the form one would need, and doesn't look like it's exposing internal plumbing.

Without this PR you have to call `setsockopt()` synchronously, which I don't want to do.