### PR TITLE
Fix MSRV check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+# .editorconfig
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools, clippy, rust-src
-      - name: Set up sccache (part 1)
-        uses: mozilla-actions/sccache-action@v0.0.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up sccache (part 2)
-        run: sccache --start-server
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - uses: taiki-e/install-action@v2
         with:
           tool: just,cargo-llvm-cov,cargo-nextest
@@ -52,12 +48,8 @@ jobs:
         with:
           toolchain: 1.75.0
           components: llvm-tools, clippy, rust-src
-      - name: Set up sccache (part 1)
-        uses: mozilla-actions/sccache-action@v0.0.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up sccache (part 2)
-        run: sccache --start-server
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - uses: taiki-e/install-action@v2
         with:
           tool: just

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,66 +1,66 @@
 name: test
 
 on:
-    push:
-        branches: ["main"]
-    pull_request:
-    merge_group:
+  push:
+    branches: ["main"]
+  pull_request:
+  merge_group:
 
 jobs:
-    test:
-        name: test
-        runs-on: ubuntu-latest
-        env:
-            RUSTC_WRAPPER: sccache
-            SCCACHE_GHA_ENABLED: true
-            CARGO_INCREMENTAL: 0
-        steps:
-            - name: Check out repository code
-              uses: actions/checkout@v4
-              with:
-                  persist-credentials: false
-            - uses: dtolnay/rust-toolchain@stable
-              with:
-                  components: llvm-tools, clippy, rust-src
-            - name: Set up sccache (part 1)
-              uses: mozilla-actions/sccache-action@v0.0.3
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-            - name: Set up sccache (part 2)
-              run: sccache --start-server
-            - uses: taiki-e/install-action@v2
-              with:
-                  tool: just,cargo-llvm-cov,cargo-nextest
-            - name: Run tests
-              run: |
-                  cd ${{ github.workspace }}
-                  just check --all-targets
-                  RUST_BACKTRACE=1 just ci-test
-            - name: Upload coverage information
-              run: |
-                  curl -Os https://uploader.codecov.io/latest/linux/codecov
-                  chmod +x codecov
-                  ./codecov
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: true
+      CARGO_INCREMENTAL: 0
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools, clippy, rust-src
+      - name: Set up sccache (part 1)
+        uses: mozilla-actions/sccache-action@v0.0.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up sccache (part 2)
+        run: sccache --start-server
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just,cargo-llvm-cov,cargo-nextest
+      - name: Run tests
+        run: |
+          cd ${{ github.workspace }}
+          just clippy --all-targets
+          RUST_BACKTRACE=1 just ci-test
+      - name: Upload coverage information
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov
 
-    msrv:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  persist-credentials: false
-            - uses: dtolnay/rust-toolchain@master
-              with:
-                  toolchain: 1.75.0
-                  components: llvm-tools, clippy, rust-src
-            - name: Set up sccache (part 1)
-              uses: mozilla-actions/sccache-action@v0.0.3
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-            - name: Set up sccache (part 2)
-              run: sccache --start-server
-            - uses: taiki-e/install-action@v2
-              with:
-                  tool: just
-            - name: Check library code with minimum supported Rust version
-              run: |
-                  just check
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.75.0
+          components: llvm-tools, clippy, rust-src
+      - name: Set up sccache (part 1)
+        uses: mozilla-actions/sccache-action@v0.0.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up sccache (part 2)
+        run: sccache --start-server
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - name: Check library code with minimum supported Rust version
+        run: |
+          just check --lib --locked

--- a/Justfile
+++ b/Justfile
@@ -29,6 +29,10 @@ test *args:
 c *args:
     just check {{args}}
 
-check *args:
+clippy *args:
 	cargo clippy {{args}} --no-default-features --features tls12,ring
 	cargo clippy {{args}} --no-default-features --features tls12,aws_lc_rs
+
+check *args:
+    cargo check {{args}} --no-default-features --features tls12,ring
+    cargo check {{args}} --no-default-features --features tls12,aws_lc_rs


### PR DESCRIPTION
re: feedback on #57 

This runs `cargo check` instead of `cargo clippy`, it does `--lib --locked`, and I forced Zed to use 2 tabs to indent the YAML somehow and ah god the test is failing now, brb.